### PR TITLE
workflows: tests: codecov-action update version to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
               fi
           done
       - name: report coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           files: coverage.txt
           flags: unittests
@@ -64,7 +64,7 @@ jobs:
               fi
           done
       - name: report coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           files: integ/coverage.txt
           flags: integtests


### PR DESCRIPTION
codecov v1 is deprecated
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1