### PR TITLE
[WIP] FieldLogger interface and logrus implementation

### DIFF
--- a/cmds/client/main.go
+++ b/cmds/client/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/insomniacslk/dhcp/iana"
 )
 
-var log = logger.GetLogger("main")
+var log = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func main() {
 	flag.Parse()

--- a/config/viper_parser.go
+++ b/config/viper_parser.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/insei/coredhcp/logger"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
@@ -18,12 +18,12 @@ import (
 //Parser is a struct for parsing yml config to Config via Viper
 type Parser struct {
 	config *Config
-	logger logrus.FieldLogger
+	logger logger.FieldLogger
 	v      *viper.Viper
 }
 
 //NewParser creates Viper based parser for Config
-func NewParser(logger logrus.FieldLogger) *Parser {
+func NewParser(logger logger.FieldLogger) *Parser {
 	return &Parser{
 		config: New(),
 		logger: logger.WithField("prefix", "config-parser"),

--- a/logger/builder.go
+++ b/logger/builder.go
@@ -1,0 +1,59 @@
+package logger
+
+import "fmt"
+
+//Builder is and interface for building logger instance. An additional level of abstraction over the logging setup.
+type Builder interface {
+	WithNoStd() Builder
+	WithFile(file string) Builder
+	LogLevel(level LogLevel) Builder
+	Build() FieldLogger
+}
+
+//LogLevel log level
+type LogLevel uint
+
+const (
+	//None level. Logging is disabled.
+	None = LogLevel(iota)
+	// Debug level. Usually only enabled when debugging. Very verbose logging.
+	Debug
+	// Info level. General operational entries about what's going on inside the
+	// application.
+	Info
+	// Warning level. Non-critical entries that deserve eyes.
+	Warning
+	// Error level. Logs. Used for errors that should definitely be noted.
+	// Commonly used for hooks to send errors to an error tracking service.
+	Error
+	// Fatal level. Logs and then calls `logger.Exit(1)`. It will exit even if the
+	// logging level is set to Panic.
+	Fatal
+)
+
+var logLevels = map[string]LogLevel{
+	"none":    None,
+	"debug":   Debug,
+	"info":    Info,
+	"warning": Warning,
+	"error":   Error,
+	"fatal":   Fatal,
+}
+
+//GetLogLevelsStrings get available logger levels as strings
+func GetLogLevelsStrings() []string {
+	var levels []string
+	for k := range logLevels {
+		levels = append(levels, k)
+	}
+	return levels
+}
+
+//LogLevelFromString get LogLevel from the string
+func LogLevelFromString(level string) (LogLevel, error) {
+	logLevel, ok := logLevels[level]
+	if !ok {
+		return Debug, fmt.Errorf("invalid log level '%s', valid log levels are %v", level, GetLogLevelsStrings())
+	}
+	return logLevel, nil
+}

--- a/logger/logrus.go
+++ b/logger/logrus.go
@@ -1,0 +1,60 @@
+package logger
+
+import (
+	"fmt"
+
+	log_prefixed "github.com/chappjc/logrus-prefix"
+	"github.com/sirupsen/logrus"
+)
+
+type logrusFormatter struct {
+	log_prefixed.TextFormatter
+}
+
+//GetLogrusFormatter returns logrus Formatter for setup logrus formatting in libraries
+func GetLogrusFormatter() logrus.Formatter {
+	return &logrusFormatter{
+		TextFormatter: log_prefixed.TextFormatter{
+			FullTimestamp: true,
+		},
+	}
+}
+
+func (f *logrusFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	messagePrefix := ""
+	server, ok := entry.Data["server"]
+	if ok {
+		messagePrefix += fmt.Sprintf("%s: ", server)
+		delete(entry.Data, "server")
+	}
+	proto, ok := entry.Data["protocol"]
+	if ok {
+		messagePrefix += fmt.Sprintf("DHCP%s: ", proto)
+		delete(entry.Data, "protocol")
+	}
+	plugin, ok := entry.Data["plugin"]
+	if ok {
+		messagePrefix += fmt.Sprintf("plugin: %s: ", plugin)
+		delete(entry.Data, "plugin")
+	}
+	entry.Message = messagePrefix + entry.Message
+	format, _ := f.TextFormatter.Format(entry)
+	if plugin != nil {
+		entry.Data["plugin"] = plugin
+	}
+	if proto != nil {
+		entry.Data["protocol"] = proto
+	}
+	if server != nil {
+		entry.Data["server"] = server
+	}
+	return format, nil
+}
+
+type logrusFieldLogger struct {
+	logrus.FieldLogger
+}
+
+func (l *logrusFieldLogger) WithField(key string, value interface{}) FieldLogger {
+	return &logrusFieldLogger{l.FieldLogger.WithField(key, value)}
+}

--- a/logger/logrusBuilder.go
+++ b/logger/logrusBuilder.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"io/ioutil"
+
+	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
+)
+
+type logrusBuilder struct {
+	logger *logrus.Logger
+}
+
+//NewLogrusBuilder creates new logger builder for logrus logger
+func NewLogrusBuilder(logger *logrus.Logger) Builder {
+	return &logrusBuilder{
+		logger,
+	}
+}
+
+//NewDefaultLogrusBuilder creates new logger builder for logrus logger
+func NewDefaultLogrusBuilder() Builder {
+	return &logrusBuilder{
+		logrus.New(),
+	}
+}
+
+// WithFile logs to the specified file in addition to the existing output.
+func (b *logrusBuilder) WithFile(logfile string) Builder {
+	b.logger.AddHook(lfshook.NewHook(logfile, &logrus.TextFormatter{}))
+	return b
+}
+
+// WithNoStd disables logging to stdout/stderr.
+func (b *logrusBuilder) WithNoStd() Builder {
+	b.logger.SetOutput(ioutil.Discard)
+	return b
+}
+
+// LogLevel sets logging level.
+func (b *logrusBuilder) LogLevel(level LogLevel) Builder {
+	var logLevelsFn = map[LogLevel]func(*logrus.Logger){
+		None:    func(l *logrus.Logger) { l.SetOutput(ioutil.Discard) },
+		Debug:   func(l *logrus.Logger) { l.SetLevel(logrus.DebugLevel) },
+		Info:    func(l *logrus.Logger) { l.SetLevel(logrus.InfoLevel) },
+		Warning: func(l *logrus.Logger) { l.SetLevel(logrus.WarnLevel) },
+		Error:   func(l *logrus.Logger) { l.SetLevel(logrus.ErrorLevel) },
+		Fatal:   func(l *logrus.Logger) { l.SetLevel(logrus.FatalLevel) },
+	}
+	fn, ok := logLevelsFn[level]
+	if ok {
+		fn(b.logger)
+	}
+	return b
+}
+
+//Build gets FieldLogger
+func (b *logrusBuilder) Build() FieldLogger {
+	b.logger.SetFormatter(GetLogrusFormatter())
+	return &logrusFieldLogger{b.logger}
+}

--- a/plugins/allocators/bitmap/bitmap.go
+++ b/plugins/allocators/bitmap/bitmap.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"github.com/insei/coredhcp/logger"
 	"github.com/willf/bitset"
 
 	"github.com/insei/coredhcp/plugins/allocators"
@@ -105,7 +105,7 @@ func (a *Allocator) Free(prefix net.IPNet) error {
 
 // NewBitmapAllocator creates a new allocator, allocating /`size` prefixes
 // carved out of the given `pool` prefix
-func NewBitmapAllocator(logger logrus.FieldLogger, pool net.IPNet, size int) (*Allocator, error) {
+func NewBitmapAllocator(logger logger.FieldLogger, pool net.IPNet, size int) (*Allocator, error) {
 	log := logger.WithField("plugin", "allocator: bitmap")
 	poolSize, _ := pool.Mask.Size()
 	allocOrder := size - poolSize
@@ -115,7 +115,7 @@ func NewBitmapAllocator(logger logrus.FieldLogger, pool net.IPNet, size int) (*A
 	} else if allocOrder >= strconv.IntSize {
 		return nil, fmt.Errorf("A pool with more than 2^%d items is not representable", size-poolSize)
 	} else if allocOrder >= 32 {
-		log.Warningln("Using a pool of more than 2^32 elements may result in large memory consumption")
+		log.Warning("Using a pool of more than 2^32 elements may result in large memory consumption")
 	}
 
 	if !(1<<uint(allocOrder) <= bitset.Cap()) {

--- a/plugins/allocators/bitmap/bitmap_test.go
+++ b/plugins/allocators/bitmap/bitmap_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/willf/bitset"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func getAllocator(bits int) *Allocator {
 	_, prefix, err := net.ParseCIDR("2001:db8::/56")

--- a/plugins/dns/plugin.go
+++ b/plugins/dns/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "dns"
@@ -27,10 +26,10 @@ var Plugin = plugins.Plugin{
 
 type pluginState struct {
 	dnsServers []net.IP
-	log        logrus.FieldLogger
+	log        logger.FieldLogger
 }
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	pState := &pluginState{log: logger.CreatePluginLogger(serverLogger, pluginName, true)}
 	if len(args) < 1 {
 		return nil, errors.New("need at least one DNS server")
@@ -46,7 +45,7 @@ func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, 
 	return pState.Handler6, nil
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginState{log: logger.CreatePluginLogger(serverLogger, pluginName, false)}
 	pState.log.Printf("loaded plugin for DHCPv4.")
 	if len(args) < 1 {

--- a/plugins/dns/plugin_test.go
+++ b/plugins/dns/plugin_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestAddServer6(t *testing.T) {
 	req, err := dhcpv6.NewMessage()

--- a/plugins/example/plugin.go
+++ b/plugins/example/plugin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/sirupsen/logrus"
 )
 
 // Plugin wraps the information necessary to register a plugin.
@@ -70,7 +69,7 @@ var Plugin = plugins.Plugin{
 }
 
 type pluginState struct {
-	log logrus.FieldLogger
+	log logger.FieldLogger
 }
 
 // setup6 is the setup function to initialize the handler for DHCPv6
@@ -80,7 +79,7 @@ type pluginState struct {
 // `exampleHandler6` function. Such function will be called for every DHCPv6
 // packet that the server receives. Remember that a handler may not be called
 // for each packet, if the handler chain is interrupted before reaching it.
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	pState := &pluginState{
 		log: logger.CreatePluginLogger(serverLogger, pluginName, true),
 	}
@@ -91,7 +90,7 @@ func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, 
 
 // setup4 behaves like setupExample6, but for DHCPv4 packets. It
 // implements the `plugin.SetupFunc4` interface.
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginState{
 		log: logger.CreatePluginLogger(serverLogger, pluginName, false),
 	}

--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -37,13 +37,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/insei/coredhcp/handler"
 	"github.com/insei/coredhcp/logger"
 	"github.com/insei/coredhcp/plugins"
-	"github.com/fsnotify/fsnotify"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -62,7 +61,7 @@ type pluginState struct {
 	recLock sync.RWMutex
 	// staticRecords holds a MAC -> IP address mapping
 	staticRecords map[string]net.IP
-	log           logrus.FieldLogger
+	log           logger.FieldLogger
 }
 
 // LoadDHCPv4Records loads the DHCPv4Records global map with records stored on
@@ -192,7 +191,7 @@ func (p *pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) 
 	return resp, true
 }
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	pState := &pluginState{
 		recLock:       sync.RWMutex{},
 		staticRecords: map[string]net.IP{},
@@ -202,7 +201,7 @@ func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, 
 	return h6, err
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginState{
 		recLock:       sync.RWMutex{},
 		staticRecords: map[string]net.IP{},

--- a/plugins/file/plugin_test.go
+++ b/plugins/file/plugin_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestLoadDHCPv4Records(t *testing.T) {
 	t.Run("valid leases", func(t *testing.T) {

--- a/plugins/leasetime/plugin.go
+++ b/plugins/leasetime/plugin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/insei/coredhcp/logger"
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "lease_time"
@@ -41,7 +40,7 @@ func (p *pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) 
 	return resp, false
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	plog := logger.CreatePluginLogger(serverLogger, pluginName, false)
 	plog.Print("loading `lease_time` plugin")
 	if len(args) < 1 {

--- a/plugins/mtu/plugin.go
+++ b/plugins/mtu/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/insei/coredhcp/logger"
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "mtu"
@@ -29,7 +28,7 @@ type pluginState struct {
 	mtu int
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	if len(args) != 1 {
 		return nil, errors.New("need one mtu value")
 	}

--- a/plugins/mtu/plugin_test.go
+++ b/plugins/mtu/plugin_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestAddServer4(t *testing.T) {
 	req, err := dhcpv4.NewDiscovery(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, dhcpv4.WithRequestedOptions(dhcpv4.OptionInterfaceMTU))

--- a/plugins/nbp/nbp.go
+++ b/plugins/nbp/nbp.go
@@ -38,7 +38,6 @@ import (
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "nbp"
@@ -52,12 +51,12 @@ var Plugin = plugins.Plugin{
 
 type pluginStateV6 struct {
 	opt59, opt60 dhcpv6.Option
-	log          logrus.FieldLogger
+	log          logger.FieldLogger
 }
 
 type pluginStateV4 struct {
 	opt66, opt67 *dhcpv4.Option
-	log          logrus.FieldLogger
+	log          logger.FieldLogger
 }
 
 func parseArgs(args ...string) (*url.URL, error) {
@@ -67,7 +66,7 @@ func parseArgs(args ...string) (*url.URL, error) {
 	return url.Parse(args[0])
 }
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	u, err := parseArgs(args...)
 	if err != nil {
 		return nil, err
@@ -90,7 +89,7 @@ func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, 
 	return pState.Handler6, nil
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	u, err := parseArgs(args...)
 	if err != nil {
 		return nil, err

--- a/plugins/netmask/plugin.go
+++ b/plugins/netmask/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/insei/coredhcp/logger"
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "netmask"
@@ -28,7 +27,7 @@ type pluginState struct {
 	netmask net.IPMask
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	plog := logger.CreatePluginLogger(serverLogger, pluginName, false)
 	plog.Printf("loaded plugin for DHCPv4")
 	if len(args) != 1 {

--- a/plugins/netmask/plugin_test.go
+++ b/plugins/netmask/plugin_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestCheckValidNetmask(t *testing.T) {
 	assert.True(t, checkValidNetmask(net.IPv4Mask(255, 255, 255, 0)))

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/insei/coredhcp/config"
 	"github.com/insei/coredhcp/handler"
-	"github.com/sirupsen/logrus"
+	"github.com/insei/coredhcp/logger"
 )
 
 // Plugin represents a plugin object.
@@ -25,13 +25,13 @@ type Plugin struct {
 var RegisteredPlugins = make(map[string]*Plugin)
 
 // SetupFunc6 defines a plugin setup function for DHCPv6
-type SetupFunc6 func(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error)
+type SetupFunc6 func(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error)
 
 // SetupFunc4 defines a plugin setup function for DHCPv6
-type SetupFunc4 func(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error)
+type SetupFunc4 func(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error)
 
 // RegisterPlugin registers a plugin.
-func RegisterPlugin(logger logrus.FieldLogger, plugin *Plugin) error {
+func RegisterPlugin(logger logger.FieldLogger, plugin *Plugin) error {
 	if plugin == nil {
 		return errors.New("cannot register nil plugin")
 	}
@@ -51,7 +51,7 @@ func RegisterPlugin(logger logrus.FieldLogger, plugin *Plugin) error {
 // plugin import time.
 // This function returns the list of loaded v6 plugins, the list of loaded v4
 // plugins, and an error if any.
-func LoadPlugins(serverLogger logrus.FieldLogger, conf *config.Config) ([]handler.Handler4, []handler.Handler6, error) {
+func LoadPlugins(serverLogger logger.FieldLogger, conf *config.Config) ([]handler.Handler4, []handler.Handler6, error) {
 	serverLogger.Print("Loading plugins...")
 	handlers4 := make([]handler.Handler4, 0)
 	handlers6 := make([]handler.Handler6, 0)

--- a/plugins/prefix/plugin.go
+++ b/plugins/prefix/plugin.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	dhcpIana "github.com/insomniacslk/dhcp/iana"
-	"github.com/sirupsen/logrus"
 	"github.com/willf/bitset"
 
 	"github.com/insei/coredhcp/handler"
@@ -45,7 +44,7 @@ var Plugin = plugins.Plugin{
 
 const leaseDuration = 3600 * time.Second
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	// - prefix: 2001:db8::/48 64
 	if len(args) < 2 {
 		return nil, errors.New("Need both a subnet and an allocation max size")
@@ -89,7 +88,7 @@ type pluginState struct {
 	// Since it's not valid utf-8 we can't use any other string function though
 	Records   map[string][]lease
 	allocator allocators.Allocator
-	log       logrus.FieldLogger
+	log       logger.FieldLogger
 }
 
 // samePrefix returns true if both prefixes are defined and equal

--- a/plugins/prefix/plugin_test.go
+++ b/plugins/prefix/plugin_test.go
@@ -13,7 +13,7 @@ import (
 	dhcpIana "github.com/insomniacslk/dhcp/iana"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestRoundTrip(t *testing.T) {
 	reqIAID := [4]uint8{0x12, 0x34, 0x56, 0x78}

--- a/plugins/range/plugin.go
+++ b/plugins/range/plugin.go
@@ -19,7 +19,6 @@ import (
 	"github.com/insei/coredhcp/plugins/allocators"
 	"github.com/insei/coredhcp/plugins/allocators/bitmap"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "range"
@@ -45,7 +44,7 @@ type pluginState struct {
 	LeaseTime time.Duration
 	leasefile *os.File
 	allocator allocators.Allocator
-	log       logrus.FieldLogger
+	log       logger.FieldLogger
 }
 
 // Handler4 handles DHCPv4 packets for the range plugin
@@ -87,7 +86,7 @@ func (p *pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) 
 	return resp, false
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	var err error
 	pState := pluginState{log: logger.CreatePluginLogger(serverLogger, pluginName, false)}
 

--- a/plugins/range/storage.go
+++ b/plugins/range/storage.go
@@ -17,7 +17,7 @@ import (
 	"github.com/insei/coredhcp/logger"
 )
 
-var log = logger.GetLogger("plugins/range")
+var log = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 // loadRecords loads the DHCPv6/v4 Records global map with records stored on
 // the specified file. The records have to be one per line, a mac address and an

--- a/plugins/router/plugin.go
+++ b/plugins/router/plugin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/insei/coredhcp/logger"
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "router"
@@ -25,10 +24,10 @@ var Plugin = plugins.Plugin{
 
 type pluginState struct {
 	routers []net.IP
-	log     logrus.FieldLogger
+	log     logger.FieldLogger
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginState{routers: []net.IP{}, log: logger.CreatePluginLogger(serverLogger, pluginName, false)}
 	pState.log.Printf("Loaded plugin for DHCPv4.")
 	if len(args) < 1 {

--- a/plugins/searchdomains/plugin.go
+++ b/plugins/searchdomains/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/rfc1035label"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "searchdomains"
@@ -41,7 +40,7 @@ var Plugin = plugins.Plugin{
 // this plugin once for the v4 and once for the v6 server.
 type pluginState struct {
 	searchList []string
-	log        logrus.FieldLogger
+	log        logger.FieldLogger
 }
 
 // copySlice creates a new copy of a string slice in memory.
@@ -53,7 +52,7 @@ func copySlice(original []string) []string {
 	return copied
 }
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	pState := &pluginState{
 		searchList: args,
 		log:        logger.CreatePluginLogger(serverLogger, pluginName, true),
@@ -62,7 +61,7 @@ func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, 
 	return pState.Handler6, nil
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginState{
 		searchList: args,
 		log:        logger.CreatePluginLogger(serverLogger, pluginName, true),

--- a/plugins/searchdomains/plugin_test.go
+++ b/plugins/searchdomains/plugin_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestAddDomains6(t *testing.T) {
 	assert := assert.New(t)

--- a/plugins/serverid/plugin.go
+++ b/plugins/serverid/plugin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/iana"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "server_id"
@@ -30,12 +29,12 @@ var Plugin = plugins.Plugin{
 type pluginStateV6 struct {
 	// v6ServerID is the DUID of the v6 server
 	serverID *dhcpv6.Duid
-	log      logrus.FieldLogger
+	log      logger.FieldLogger
 }
 
 type pluginStateV4 struct {
 	serverID net.IP
-	log      logrus.FieldLogger
+	log      logger.FieldLogger
 }
 
 // Handler6 handles DHCPv6 packets for the server_id plugin.
@@ -101,7 +100,7 @@ func (p pluginStateV4) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool)
 	return resp, false
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginStateV4{log: logger.CreatePluginLogger(serverLogger, pluginName, false)}
 	pState.log.Printf("loading `server_id` plugin for DHCPv4 with args: %v", args)
 	if len(args) < 1 {
@@ -118,7 +117,7 @@ func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, 
 	return pState.Handler4, nil
 }
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	pState := &pluginStateV6{log: logger.CreatePluginLogger(serverLogger, pluginName, true)}
 	pState.log.Printf("loading `server_id` plugin for DHCPv6 with args: %v", args)
 	if len(args) < 2 {

--- a/plugins/serverid/plugin_test.go
+++ b/plugins/serverid/plugin_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func makeLLDUID(mac string) (*dhcpv6.Duid, error) {
 	hwaddr, err := net.ParseMAC(mac)

--- a/plugins/sleep/plugin.go
+++ b/plugins/sleep/plugin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "sleep"
@@ -44,10 +43,10 @@ var Plugin = plugins.Plugin{
 
 type pluginState struct {
 	delay time.Duration
-	log   logrus.FieldLogger
+	log   logger.FieldLogger
 }
 
-func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, error) {
+func setup6(serverLogger logger.FieldLogger, args ...string) (handler.Handler6, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("want exactly one argument, got %d", len(args))
 	}
@@ -63,7 +62,7 @@ func setup6(serverLogger logrus.FieldLogger, args ...string) (handler.Handler6, 
 	return makeSleepHandler6(pState), nil
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("want exactly one argument, got %d", len(args))
 	}

--- a/plugins/staticroute/plugin.go
+++ b/plugins/staticroute/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/insei/coredhcp/logger"
 	"github.com/insei/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 const pluginName = "staticroute"
@@ -26,10 +25,10 @@ var Plugin = plugins.Plugin{
 
 type pluginState struct {
 	routes dhcpv4.Routes
-	log    logrus.FieldLogger
+	log    logger.FieldLogger
 }
 
-func setup4(serverLogger logrus.FieldLogger, args ...string) (handler.Handler4, error) {
+func setup4(serverLogger logger.FieldLogger, args ...string) (handler.Handler4, error) {
 	pState := &pluginState{
 		routes: make(dhcpv4.Routes, 0),
 		log:    logger.CreatePluginLogger(serverLogger, pluginName, false),

--- a/plugins/staticroute/plugin_test.go
+++ b/plugins/staticroute/plugin_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testsLogger = logger.GetLogger("tests")
+var testsLogger = logger.NewDefaultLogrusBuilder().Build().WithField("prefix", "tests")
 
 func TestSetup4(t *testing.T) {
 	// no args

--- a/server/sendEthernet.go
+++ b/server/sendEthernet.go
@@ -2,6 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+//go:build linux
 // +build linux
 
 package server
@@ -13,15 +14,15 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/insei/coredhcp/logger"
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/sirupsen/logrus"
 )
 
 //this function sends an unicast to the hardware address defined in resp.ClientHWAddr,
 //the layer3 destination address is still the broadcast address;
 //iface: the interface where the DHCP message should be sent;
 //resp: DHCPv4 struct, which should be sent;
-func sendEthernet(logger logrus.FieldLogger, iface net.Interface, resp *dhcpv4.DHCPv4) error {
+func sendEthernet(logger logger.FieldLogger, iface net.Interface, resp *dhcpv4.DHCPv4) error {
 
 	eth := layers.Ethernet{
 		EthernetType: layers.EthernetTypeIPv4,

--- a/server/serve.go
+++ b/server/serve.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net"
 
-	"github.com/sirupsen/logrus"
+	"github.com/insei/coredhcp/logger"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 
@@ -24,14 +24,14 @@ type listener6 struct {
 	*ipv6.PacketConn
 	net.Interface
 	handlers []handler.Handler6
-	log      logrus.FieldLogger
+	log      logger.FieldLogger
 }
 
 type listener4 struct {
 	*ipv4.PacketConn
 	net.Interface
 	handlers []handler.Handler4
-	log      logrus.FieldLogger
+	log      logger.FieldLogger
 }
 
 type listener interface {
@@ -42,10 +42,10 @@ type listener interface {
 type Servers struct {
 	listeners []listener
 	errors    chan error
-	Log       logrus.FieldLogger
+	Log       logger.FieldLogger
 }
 
-func listen4(logger logrus.FieldLogger, a *net.UDPAddr) (*listener4, error) {
+func listen4(logger logger.FieldLogger, a *net.UDPAddr) (*listener4, error) {
 	var err error
 	l4 := listener4{log: logger}
 	udpConn, err := server4.NewIPv4UDPConn(a.Zone, a)
@@ -79,7 +79,7 @@ func listen4(logger logrus.FieldLogger, a *net.UDPAddr) (*listener4, error) {
 	return &l4, nil
 }
 
-func listen6(logger logrus.FieldLogger, a *net.UDPAddr) (*listener6, error) {
+func listen6(logger logger.FieldLogger, a *net.UDPAddr) (*listener6, error) {
 	l6 := listener6{log: logger}
 	udpconn, err := server6.NewIPv6UDPConn(a.Zone, a)
 	if err != nil {
@@ -113,7 +113,7 @@ func listen6(logger logrus.FieldLogger, a *net.UDPAddr) (*listener6, error) {
 
 // Start will start the server asynchronously. See `Wait` to wait until
 // the execution ends.
-func Start(logger logrus.FieldLogger, config *config.Config) (*Servers, error) {
+func Start(logger logger.FieldLogger, config *config.Config) (*Servers, error) {
 	serverLogger := logger.WithField("prefix", config.Name)
 	handlers4, handlers6, err := plugins.LoadPlugins(serverLogger, config)
 	if err != nil {
@@ -126,7 +126,7 @@ func Start(logger logrus.FieldLogger, config *config.Config) (*Servers, error) {
 
 	// listen
 	if config.Server6 != nil {
-		serverLogger.Println("Starting DHCPv6 server")
+		serverLogger.Print("Starting DHCPv6 server")
 		for _, addr := range config.Server6.Addresses {
 			var l6 *listener6
 			l6, err = listen6(serverLogger, &addr)
@@ -142,7 +142,7 @@ func Start(logger logrus.FieldLogger, config *config.Config) (*Servers, error) {
 	}
 
 	if config.Server4 != nil {
-		serverLogger.Println("Starting DHCPv4 server")
+		serverLogger.Print("Starting DHCPv4 server")
 		for _, addr := range config.Server4.Addresses {
 			var l4 *listener4
 			l4, err = listen4(serverLogger, &addr)


### PR DESCRIPTION
* Now coredhcp can use any logger that implement logger.FieldLogger interface
* Added logger.Builder interface as an additional level of abstraction over the logging setup. It's used only in cmds/coredchp/main.go and in the tests.